### PR TITLE
Add Rails::Auth::ErrorPage::Middleware

### DIFF
--- a/lib/rails/auth/error_page/middleware.rb
+++ b/lib/rails/auth/error_page/middleware.rb
@@ -1,0 +1,21 @@
+module Rails
+  module Auth
+    module ErrorPage
+      # Render an error page in the event Rails::Auth::NotAuthorizedError is raised
+      class Middleware
+        def initialize(app, page_body: nil)
+          fail TypeError, "page_body must be a String" unless page_body.is_a?(String)
+
+          @app       = app
+          @page_body = page_body.freeze
+        end
+
+        def call(env)
+          @app.call(env)
+        rescue Rails::Auth::NotAuthorizedError
+          [403, {}, [@page_body]]
+        end
+      end
+    end
+  end
+end

--- a/lib/rails/auth/rack.rb
+++ b/lib/rails/auth/rack.rb
@@ -12,6 +12,8 @@ require "rails/auth/acl"
 require "rails/auth/acl/middleware"
 require "rails/auth/acl/resource"
 
+require "rails/auth/error_page/middleware"
+
 require "rails/auth/x509/filter/pem"
 require "rails/auth/x509/filter/java" if defined?(JRUBY_VERSION)
 require "rails/auth/x509/matcher"

--- a/spec/rails/auth/error_page/middleware_spec.rb
+++ b/spec/rails/auth/error_page/middleware_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Rails::Auth::ErrorPage::Middleware do
+  let(:request)    { Rack::MockRequest.env_for("https://www.example.com") }
+  let(:error_page) { "<h1> Unauthorized!!! </h1>" }
+
+  subject(:middleware) { described_class.new(app, page_body: error_page) }
+
+  context "access granted" do
+    let(:code) { 200 }
+    let(:app)  { ->(env) { [code, env, "Hello, world!"] } }
+
+    it "renders the expected response" do
+      response = middleware.call(request)
+      expect(response.first).to eq code
+    end
+  end
+
+  context "access denied" do
+    let(:app) { ->(_env) { fail(Rails::Auth::NotAuthorizedError, "not authorized!") } }
+
+    it "renders the error page" do
+      code, _env, body = middleware.call(request)
+      expect(code).to eq 403
+      expect(body).to eq [error_page]
+    end
+  end
+end


### PR DESCRIPTION
This is a middleware that can be used to render a static error page when `Rails::Auth::NotAuthorizedError` is raised by a middleware higher in the chain.