### PR TITLE
Add #attributes method to matchers and X.509 certs

### DIFF
--- a/lib/rails/auth/acl/matchers/allow_all.rb
+++ b/lib/rails/auth/acl/matchers/allow_all.rb
@@ -13,6 +13,13 @@ module Rails
           def match(_env)
             @enabled
           end
+
+          # Generates inspectable attributes for debugging
+          #
+          # @return [true, false] is the matcher enabled?
+          def attributes
+            @enabled
+          end
         end
       end
     end

--- a/lib/rails/auth/x509/certificate.rb
+++ b/lib/rails/auth/x509/certificate.rb
@@ -35,6 +35,16 @@ module Rails
           @subject["OU".freeze]
         end
         alias organizational_unit ou
+
+        # Generates inspectable attributes for debugging
+        #
+        # @return [Hash] hash containing parts of the certificate subject (cn, ou)
+        def attributes
+          {
+            cn: cn,
+            ou: ou
+          }
+        end
       end
     end
   end

--- a/lib/rails/auth/x509/matcher.rb
+++ b/lib/rails/auth/x509/matcher.rb
@@ -6,7 +6,7 @@ module Rails
         # @option options [String] cn Common Name of the subject
         # @option options [String] ou Organizational Unit of the subject
         def initialize(options)
-          @options = options
+          @options = options.freeze
         end
 
         # @param [Hash] env Rack environment
@@ -15,6 +15,13 @@ module Rails
           return false unless certificate
 
           @options.all? { |name, value| certificate[name] == value }
+        end
+
+        # Generates inspectable attributes for debugging
+        #
+        # @return [Hash] hash containing parts of the certificate subject to match (cn, ou)
+        def attributes
+          @options
         end
       end
     end

--- a/spec/rails/auth/acl/matchers/allow_all_spec.rb
+++ b/spec/rails/auth/acl/matchers/allow_all_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Rails::Auth::ACL::Matchers::AllowAll do
-  let(:predicate)   { described_class.new(enabled) }
+  let(:matcher)     { described_class.new(enabled) }
   let(:example_env) { env_for(:get, "/") }
 
   describe "#initialize" do
@@ -17,7 +17,7 @@ RSpec.describe Rails::Auth::ACL::Matchers::AllowAll do
       let(:enabled) { true }
 
       it "allows all requests" do
-        expect(predicate.match(example_env)).to eq true
+        expect(matcher.match(example_env)).to eq true
       end
     end
 
@@ -25,8 +25,13 @@ RSpec.describe Rails::Auth::ACL::Matchers::AllowAll do
       let(:enabled) { false }
 
       it "rejects all requests" do
-        expect(predicate.match(example_env)).to eq false
+        expect(matcher.match(example_env)).to eq false
       end
     end
+  end
+
+  it "knows its attributes" do
+    matcher = described_class.new(true)
+    expect(matcher.attributes).to eq true
   end
 end

--- a/spec/rails/auth/x509/certificate_spec.rb
+++ b/spec/rails/auth/x509/certificate_spec.rb
@@ -24,4 +24,8 @@ RSpec.describe Rails::Auth::X509::Certificate do
   it "knows its #ou" do
     expect(example_certificate.ou).to eq example_ou
   end
+
+  it "knows its attributes" do
+    expect(example_certificate.attributes).to eq(cn: example_cn, ou: example_ou)
+  end
 end

--- a/spec/rails/auth/x509/matcher_spec.rb
+++ b/spec/rails/auth/x509/matcher_spec.rb
@@ -9,13 +9,20 @@ RSpec.describe Rails::Auth::X509::Matcher do
     { Rails::Auth::CREDENTIALS_ENV_KEY => { "x509" => example_certificate } }
   end
 
-  it "matches against a valid Rails::Auth::X509::Credential" do
-    matcher = described_class.new(ou: example_ou)
-    expect(matcher.match(example_env)).to eq true
+  describe "#match" do
+    it "matches against a valid Rails::Auth::X509::Credential" do
+      matcher = described_class.new(ou: example_ou)
+      expect(matcher.match(example_env)).to eq true
+    end
+
+    it "doesn't match if the subject mismatches" do
+      matcher = described_class.new(ou: another_ou)
+      expect(matcher.match(example_env)).to eq false
+    end
   end
 
-  it "doesn't match if the subject mismatches" do
-    matcher = described_class.new(ou: another_ou)
-    expect(matcher.match(example_env)).to eq false
+  it "knows its attributes" do
+    matcher = described_class.new(ou: example_ou)
+    expect(matcher.attributes).to eq(ou: example_ou)
   end
 end


### PR DESCRIPTION
These are useful with Rails::Auth::ErrorPage::DebugMiddleware