### PR TITLE
Support for optionally matching hostnames in ACL resources

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,4 +15,7 @@ Metrics/MethodLength:
   Max: 25
 
 Metrics/AbcSize:
-  Max: 20
+  Max: 25
+
+Metrics/CyclomaticComplexity:
+  Max: 8

--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ Resources are defined by the following constraints:
 * **path**: A regular expression to match the path. `\A` and `\z` are added by
   default to the beginning and end of the regex to ensure the entire path and
   not a substring is matched.
+* **host** (optional): a regular expression to match the `Host:` header passed
+  by the client. Useful if your app services traffic for more than one hostname
+  and you'd like to restrict ACLs by host.
 
 Once you've defined an ACL, you'll need to create a corresponding ACL object
 in Ruby and a middleware to authorize requests using that ACL. Add the

--- a/lib/rails/auth/acl.rb
+++ b/lib/rails/auth/acl.rb
@@ -61,7 +61,7 @@ module Rails
       # @return [Array<Rails::Auth::ACL::Resource>] matching resources
       #
       def matching_resources(env)
-        @resources.find_all { |resource| resource.match_method_and_path(env) }
+        @resources.find_all { |resource| resource.match!(env) }
       end
 
       private

--- a/lib/rails/auth/acl/resource.rb
+++ b/lib/rails/auth/acl/resource.rb
@@ -5,13 +5,13 @@ module Rails
     class ACL
       # Rules for a particular route
       class Resource
-        attr_reader :http_methods, :path, :predicates
+        attr_reader :http_methods, :path, :host, :predicates
 
         # Valid HTTP methods
         HTTP_METHODS = %w(GET HEAD PUT POST DELETE OPTIONS PATCH LINK UNLINK).freeze
 
         # Options allowed for resource matchers
-        VALID_OPTIONS = %w(method path).freeze
+        VALID_OPTIONS = %w(method path host).freeze
 
         # @option :options [String] :method HTTP method allowed ("ALL" for all methods)
         # @option :options [String] :path path to the resource (regex syntax allowed)
@@ -25,9 +25,16 @@ module Rails
             raise ParseError, "unrecognized key in ACL resource: #{extra_keys.first}"
           end
 
-          @http_methods = extract_methods(options["method"])
-          @path         = /\A#{options.fetch("path")}\z/
+          methods = options["method"] || raise(ParseError, "no 'method' key in resource: #{options.inspect}")
+          path    = options["path"]   || raise(ParseError, "no 'path' key in resource: #{options.inspect}")
+
+          @http_methods = extract_methods(methods)
+          @path         = /\A#{path}\z/
           @predicates   = predicates.freeze
+
+          # Unlike method and path, host is optional
+          host = options["host"]
+          @host = /\A#{host}\z/ if host
         end
 
         # Match this resource against the given Rack environment, checking all
@@ -38,20 +45,21 @@ module Rails
         # @return [Boolean] resource and predicates match the given request
         #
         def match(env)
-          return false unless match_method_and_path(env)
+          return false unless match!(env)
           @predicates.any? { |_name, predicate| predicate.match(env) }
         end
 
-        # Match *only* the request method/path against the given Rack environment.
+        # Match *only* the request method/path/host against the given Rack environment.
         # Predicates are NOT checked.
         #
         # @param [Hash] :env Rack environment
         #
         # @return [Boolean] method and path *only* match the given environment
         #
-        def match_method_and_path(env)
+        def match!(env)
           return false unless @http_methods.nil? || @http_methods.include?(env["REQUEST_METHOD".freeze])
           return false unless @path =~ env["REQUEST_PATH".freeze]
+          return false unless @host.nil? || @host =~ env["HTTP_HOST".freeze]
           true
         end
 


### PR DESCRIPTION
For apps that service more than one hostname, it's useful to restrict ACLs by the hostname.