### PR TITLE
Use PATH_INFO instead of REQUEST_PATH

### DIFF
--- a/lib/rails/auth/acl/resource.rb
+++ b/lib/rails/auth/acl/resource.rb
@@ -58,7 +58,7 @@ module Rails
         #
         def match!(env)
           return false unless @http_methods.nil? || @http_methods.include?(env["REQUEST_METHOD".freeze])
-          return false unless @path =~ env["REQUEST_PATH".freeze]
+          return false unless @path =~ env["PATH_INFO".freeze]
           return false unless @host.nil? || @host =~ env["HTTP_HOST".freeze]
           true
         end

--- a/lib/rails/auth/error_page/debug_page.html.erb
+++ b/lib/rails/auth/error_page/debug_page.html.erb
@@ -72,7 +72,7 @@
         </tr>
         <tr>
           <td class="label">Path</td>
-          <td><%= h(env["REQUEST_PATH"]) %></td>
+          <td><%= h(env["PATH_INFO"]) %></td>
         </tr>
         <tr>
           <td class="label">Host</td>

--- a/lib/rails/auth/rspec/helper_methods.rb
+++ b/lib/rails/auth/rspec/helper_methods.rb
@@ -35,7 +35,7 @@ module Rails
 
             env = {
               "REQUEST_METHOD" => method,
-              "REQUEST_PATH"   => self.class.description
+              "PATH_INFO"      => self.class.description
             }
 
             certificates.each do |type, value|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,9 +18,10 @@ def fixture_path(*args)
   Pathname.new(File.expand_path("../fixtures", __FILE__)).join(*args)
 end
 
-def env_for(method, path)
+def env_for(method, path, host = "127.0.0.1")
   {
     "REQUEST_METHOD" => method.to_s.upcase,
-    "REQUEST_PATH"   => path
+    "PATH_INFO"      => path,
+    "HTTP_HOST"      => host
   }
 end


### PR DESCRIPTION
The `PATH_INFO` Rack environment value seems to be present in all Rack contexts, whereas `REQUEST_PATH` is sometimes missing.