### PR TITLE
Rails::Auth::Credentials::InjectorMiddleware

### DIFF
--- a/lib/rails/auth/credentials/injector_middleware.rb
+++ b/lib/rails/auth/credentials/injector_middleware.rb
@@ -1,0 +1,20 @@
+module Rails
+  module Auth
+    module Credentials
+      # A middleware for injecting an arbitrary credentials hash into the Rack environment
+      # This is intended for development and testing purposes where you would like to
+      # simulate a given X.509 certificate being used in a request or user logged in
+      class InjectorMiddleware
+        def initialize(app, credentials)
+          @app = app
+          @credentials = credentials
+        end
+
+        def call(env)
+          env[Rails::Auth::CREDENTIALS_ENV_KEY] = @credentials
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails/auth/rack.rb
+++ b/lib/rails/auth/rack.rb
@@ -6,12 +6,14 @@ require "openssl"
 
 require "rails/auth/version"
 
-require "rails/auth/credentials"
 require "rails/auth/exceptions"
 
 require "rails/auth/acl"
 require "rails/auth/acl/middleware"
 require "rails/auth/acl/resource"
+
+require "rails/auth/credentials"
+require "rails/auth/credentials/injector_middleware"
 
 require "rails/auth/error_page/middleware"
 require "rails/auth/error_page/debug_middleware"

--- a/spec/rails/auth/credentials/injector_middleware_spec.rb
+++ b/spec/rails/auth/credentials/injector_middleware_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Rails::Auth::Credentials::InjectorMiddleware do
+  let(:request)     { Rack::MockRequest.env_for("https://www.example.com") }
+  let(:app)         { ->(env) { [200, env, "Hello, world!"] } }
+  let(:middleware)  { described_class.new(app, credentials) }
+  let(:credentials) { { "foo" => "bar" } }
+
+  it "overrides rails-auth credentials in the rack environment" do
+    _response, env = middleware.call(request)
+    expect(env[Rails::Auth::CREDENTIALS_ENV_KEY]).to eq credentials
+  end
+end


### PR DESCRIPTION
This middleware supports injecting arbitrary credentials into the Rack environment.

It's useful for development and testing purposes, simulating credentials for a request without actually using other credential middlewares. This lets you simulate being logged in during development, or which credentials clients have in tests.