### PR TITLE
Use explicit HTTP_METHODS whitelist when 'ALL' method is used

### DIFF
--- a/lib/rails/auth/acl/resource.rb
+++ b/lib/rails/auth/acl/resource.rb
@@ -57,7 +57,7 @@ module Rails
         # @return [Boolean] method and path *only* match the given environment
         #
         def match!(env)
-          return false unless @http_methods.nil? || @http_methods.include?(env["REQUEST_METHOD".freeze])
+          return false unless @http_methods.include?(env["REQUEST_METHOD".freeze])
           return false unless @path =~ env["PATH_INFO".freeze]
           return false unless @host.nil? || @host =~ env["HTTP_HOST".freeze]
           true
@@ -68,7 +68,8 @@ module Rails
         def extract_methods(methods)
           methods = Array(methods)
 
-          return nil if methods.include?("ALL")
+          return HTTP_METHODS if methods == ["ALL"]
+          raise ParseError, "method 'ALL' cannot be used with other methods" if methods.include?("ALL")
 
           methods.each do |method|
             raise ParseError, "invalid HTTP method: #{method}" unless HTTP_METHODS.include?(method)

--- a/spec/rails/auth/acl/resource_spec.rb
+++ b/spec/rails/auth/acl/resource_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Rails::Auth::ACL::Resource do
         {}
       )
 
-      expect(resource.http_methods).to eq nil
+      expect(resource.http_methods).to eq Rails::Auth::ACL::Resource::HTTP_METHODS
     end
 
     context "errors" do


### PR DESCRIPTION
Before ALL functioned as a blanket method whitelist.

This constrains which methods are allowed to the ones in Rails::Auth::ACL::Resource::HTTP_METHODS