### PR TITLE
Allow outside middleware to mark a request as authorized

### DIFF
--- a/lib/rails/auth/acl/middleware.rb
+++ b/lib/rails/auth/acl/middleware.rb
@@ -22,7 +22,7 @@ module Rails
         end
 
         def call(env)
-          raise NotAuthorizedError, "unauthorized request" unless @acl.match(env)
+          raise NotAuthorizedError, "unauthorized request" unless Rails::Auth.authorized?(env) || @acl.match(env)
           @app.call(env)
         end
       end

--- a/lib/rails/auth/override.rb
+++ b/lib/rails/auth/override.rb
@@ -1,0 +1,29 @@
+module Rails
+  # Modular resource-based authentication and authorization for Rails/Rack
+  module Auth
+    # Rack environment key for marking external authorization
+    AUTHORIZED_ENV_KEY = "rails-auth.authorized".freeze
+
+    # Functionality allowing external middleware to override our ACL check process
+    module Override
+      # Mark a request as externally authorized. Causes ACL checks to be skipped.
+      #
+      # @param [Hash] :env Rack environment
+      #
+      def authorized!(env)
+        env[AUTHORIZED_ENV_KEY] = true
+      end
+
+      # Check whether a request has been externally authorized? Used to bypass
+      # ACL check.
+      #
+      # @param [Hash] :env Rack environment
+      #
+      def authorized?(env)
+        env.fetch(AUTHORIZED_ENV_KEY, false)
+      end
+    end
+
+    extend Override
+  end
+end

--- a/lib/rails/auth/rack.rb
+++ b/lib/rails/auth/rack.rb
@@ -8,6 +8,8 @@ require "rails/auth/version"
 
 require "rails/auth/exceptions"
 
+require "rails/auth/override"
+
 require "rails/auth/acl"
 require "rails/auth/acl/middleware"
 require "rails/auth/acl/resource"

--- a/spec/rails/auth/acl/middleware_spec.rb
+++ b/spec/rails/auth/acl/middleware_spec.rb
@@ -21,4 +21,24 @@ RSpec.describe Rails::Auth::ACL::Middleware do
       expect { expect(middleware.call(request)) }.to raise_error(Rails::Auth::NotAuthorizedError)
     end
   end
+
+  context "externally authorized requests" do
+    let(:authorized) { false }
+    let(:external_middleware) do
+      Class.new do
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          Rails::Auth.authorized!(env)
+          @app.call(env)
+        end
+      end
+    end
+
+    it "allows externally authorized requests" do
+      expect(external_middleware.new(middleware).call(request)[0]).to eq 200
+    end
+  end
 end


### PR DESCRIPTION
Add `authorized!(env)` and `authorized?(env)` to `Rails::Auth`. Outside middleware can use `authorized!` to mark a request as being exempt from the ACL check. Allows other authorization systems to play nicely on a per-request basis (for routes that they will already be authorizing, for instance).