### PR TITLE
Make add_credential idempotent

### DIFF
--- a/lib/rails/auth/credentials.rb
+++ b/lib/rails/auth/credentials.rb
@@ -25,7 +25,14 @@ module Rails
       def add_credential(env, type, credential)
         credentials = env[CREDENTIALS_ENV_KEY] ||= {}
 
+        # Adding a credential is idempotent, so attempting to reregister
+        # the same credential should be harmless
+        return env if credentials.key?(type) && credentials[type] == credential
+
+        # raise if we already have a cred, but it didn't short-circuit as
+        # being == to the one supplied
         raise ArgumentError, "credential #{type} already added to request" if credentials.key?(type)
+
         credentials[type] = credential
 
         env

--- a/lib/rails/auth/x509/certificate.rb
+++ b/lib/rails/auth/x509/certificate.rb
@@ -45,6 +45,14 @@ module Rails
             ou: ou
           }
         end
+
+        # Compare ourself to another object by ensuring that it has the same type
+        # and that its certificate pem is the same as ours
+        def ==(other)
+          other.is_a?(self.class) && other.certificate.to_der == certificate.to_der
+        end
+
+        alias eql? ==
       end
     end
   end

--- a/lib/rails/auth/x509/filter/pem.rb
+++ b/lib/rails/auth/x509/filter/pem.rb
@@ -5,7 +5,7 @@ module Rails
         # Extract OpenSSL::X509::Certificates from Privacy Enhanced Mail (PEM) certificates
         class Pem
           def call(pem)
-            OpenSSL::X509::Certificate.new(pem).freeze
+            OpenSSL::X509::Certificate.new(pem.delete("\t")).freeze
           end
         end
       end

--- a/spec/rails/auth/credentials_spec.rb
+++ b/spec/rails/auth/credentials_spec.rb
@@ -25,12 +25,28 @@ RSpec.describe Rails::Auth::Credentials do
       expect(Rails::Auth.credentials(example_env)[example_type]).to eq example_credential
     end
 
-    it "raises ArgumentError if the same type of credential is added twice" do
-      Rails::Auth.add_credential(example_env, example_type, example_credential)
+    context "when called twice for the same credential type" do
+      let(:second_credential) { double(:credential2) }
 
-      expect do
+      it "succeeds if the credentials are the same" do
+        allow(example_credential).to receive(:==).and_return(true)
+
         Rails::Auth.add_credential(example_env, example_type, example_credential)
-      end.to raise_error(ArgumentError)
+
+        expect do
+          Rails::Auth.add_credential(example_env, example_type, second_credential)
+        end.to_not raise_error
+      end
+
+      it "raises ArgumentError if the credentials are different" do
+        allow(example_credential).to receive(:==).and_return(false)
+
+        Rails::Auth.add_credential(example_env, example_type, example_credential)
+
+        expect do
+          Rails::Auth.add_credential(example_env, example_type, second_credential)
+        end.to raise_error(ArgumentError)
+      end
     end
   end
 end

--- a/spec/rails/auth/x509/certificate_spec.rb
+++ b/spec/rails/auth/x509/certificate_spec.rb
@@ -28,4 +28,11 @@ RSpec.describe Rails::Auth::X509::Certificate do
   it "knows its attributes" do
     expect(example_certificate.attributes).to eq(cn: example_cn, ou: example_ou)
   end
+
+  it "compares certificate objects by comparing their certificates" do
+    second_cert = OpenSSL::X509::Certificate.new(cert_path("valid.crt").read)
+    second_certificate = described_class.new(second_cert)
+
+    expect(example_certificate).to be_eql second_certificate
+  end
 end


### PR DESCRIPTION
If called with the same type and credentials that return true for `==`, don't raise an ArgumentError. Instead, return the existing env.

Add an `==` implementation to X509::Certificate, comparing the two objects via `certificate.to_der`.

Remove tabs when loading x509 pems via the pem filter.

Built on #25, so the diff will clean up once that merges.