### PR TITLE
Handle javax.servlet.request.X509Certificate arrays

### DIFF
--- a/lib/rails/auth/x509/filter/java.rb
+++ b/lib/rails/auth/x509/filter/java.rb
@@ -7,8 +7,9 @@ module Rails
       module Filter
         # Extract OpenSSL::X509::Certificates from Java's sun.security.x509.X509CertImpl
         class Java
-          def call(cert)
-            OpenSSL::X509::Certificate.new(extract_der(cert)).freeze
+          def call(certs)
+            return unless certs
+            OpenSSL::X509::Certificate.new(extract_der(certs[0])).freeze
           end
 
           private

--- a/spec/rails/auth/x509/middleware_spec.rb
+++ b/spec/rails/auth/x509/middleware_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Rails::Auth::X509::Middleware do
       it "extracts Rails::Auth::Credential::X509 from a Java::SunSecurityX509::X509CertImpl" do
         skip "JRuby only" unless defined?(JRUBY_VERSION)
 
-        _response, env = middleware.call(request.merge(example_key => java_cert))
+        _response, env = middleware.call(request.merge(example_key => [java_cert]))
 
         credential = Rails::Auth.credentials(env).fetch("x509")
         expect(credential).to be_a Rails::Auth::X509::Certificate


### PR DESCRIPTION
Apparently these are passed into the Rack environment as an array instead of an individual cert, so extract the first one and attempt to verify it.