### PR TITLE
Add a attr_reader for Rails::Auth::ACL#resources

### DIFF
--- a/lib/rails/auth/acl.rb
+++ b/lib/rails/auth/acl.rb
@@ -5,6 +5,8 @@ module Rails
   module Auth
     # Route-based access control lists
     class ACL
+      attr_reader :resources
+
       # Predicate matchers available by default in ACLs
       DEFAULT_MATCHERS = {
         allow_all: Matchers::AllowAll


### PR DESCRIPTION
It's useful to be able to access these for the purpose of debugging authorization failures.

They're frozen anyway, so this hopefully won't have a negative reliability or security impact.

cc @thirstscolr @ewr @zanker
