### PR TITLE
Lock to Rack 1.x and ActiveSupport 4.x in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ group :development do
 end
 
 group :development, :test do
+  # Workaround for: https://github.com/bundler/bundler/pull/4650
+  gem "rack", "~> 1.x"
+  gem "activesupport", "~> 4"
+
   gem "rake"
   gem "rspec"
   gem "rubocop", "0.38.0"


### PR DESCRIPTION
This library isn't (necessarily) incompatible with Rails 5, however we test on older Rubies, and it's broken on those.

This appears to be due to a Bundler bug:

https://github.com/bundler/bundler/pull/4650