### PR TITLE
Render JSON error responses from Rails::Auth::ErrorPage

### DIFF
--- a/lib/rails/auth/error_page/middleware.rb
+++ b/lib/rails/auth/error_page/middleware.rb
@@ -3,17 +3,36 @@ module Rails
     module ErrorPage
       # Render an error page in the event Rails::Auth::NotAuthorizedError is raised
       class Middleware
-        def initialize(app, page_body: nil)
+        def initialize(app, page_body: nil, json_body: { message: "Access denied" })
           raise TypeError, "page_body must be a String" unless page_body.is_a?(String)
 
           @app       = app
           @page_body = page_body.freeze
+          @json_body = json_body.to_json
         end
 
         def call(env)
           @app.call(env)
         rescue Rails::Auth::NotAuthorizedError
-          [403, { "Content-Type" => "text/html" }, [@page_body]]
+          access_denied(env)
+        end
+
+        private
+
+        def access_denied(env)
+          case response_format(env)
+          when :json
+            [403, { "X-Powered-By" => "rails-auth", "Content-Type" => "application/json" }, [@json_body]]
+          else
+            [403, { "X-Powered-By" => "rails-auth", "Content-Type" => "text/html" }, [@page_body]]
+          end
+        end
+
+        def response_format(env)
+          accept_format = env["HTTP_ACCEPT"]
+          return :json if accept_format && accept_format.downcase.start_with?("application/json")
+          return :json if env["PATH_INFO"] && env["PATH_INFO"].end_with?(".json")
+          nil
         end
       end
     end

--- a/spec/rails/auth/error_page/middleware_spec.rb
+++ b/spec/rails/auth/error_page/middleware_spec.rb
@@ -4,23 +4,52 @@ RSpec.describe Rails::Auth::ErrorPage::Middleware do
 
   subject(:middleware) { described_class.new(app, page_body: error_page) }
 
-  context "access granted" do
-    let(:code) { 200 }
-    let(:app)  { ->(env) { [code, env, "Hello, world!"] } }
+  context "unspecified content type" do
+    describe "access granted" do
+      let(:code) { 200 }
+      let(:app)  { ->(env) { [code, env, "Hello, world!"] } }
 
-    it "renders the expected response" do
-      response = middleware.call(request)
-      expect(response.first).to eq code
+      it "renders the expected response" do
+        response = middleware.call(request)
+        expect(response.first).to eq code
+      end
+    end
+
+    describe "access denied" do
+      let(:app) { ->(_env) { raise(Rails::Auth::NotAuthorizedError, "not authorized!") } }
+
+      it "renders the error page" do
+        code, _env, body = middleware.call(request)
+        expect(code).to eq 403
+        expect(body).to eq [error_page]
+      end
     end
   end
 
-  context "access denied" do
-    let(:app) { ->(_env) { raise(Rails::Auth::NotAuthorizedError, "not authorized!") } }
+  context "JSON content type" do
+    let(:app)     { ->(_env) { raise(Rails::Auth::NotAuthorizedError, "not authorized!") } }
+    let(:message) { { message: "Access denied" }.to_json }
 
-    it "renders the error page" do
-      code, _env, body = middleware.call(request)
-      expect(code).to eq 403
-      expect(body).to eq [error_page]
+    context "via request path" do
+      let(:request) { Rack::MockRequest.env_for("https://www.example.com/foobar.json?x=1&y=2") }
+
+      it "renders a JSON response" do
+        code, env, body = middleware.call(request)
+        expect(code).to eq 403
+        expect(env["Content-Type"]).to eq "application/json"
+        expect(body).to eq [message]
+      end
+    end
+
+    context "via Accept header" do
+      it "renders a JSON response" do
+        request["HTTP_ACCEPT"] = "application/json"
+
+        code, env, body = middleware.call(request)
+        expect(code).to eq 403
+        expect(env["Content-Type"]).to eq "application/json"
+        expect(body).to eq [message]
+      end
     end
   end
 end


### PR DESCRIPTION
This detects if a request is for JSON, and if so, renders a JSON response instead of an HTML one.