### PR TITLE
Rails::Auth::ConfigBuilder

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ AllCops:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
+Style/ModuleFunction:
+  Enabled: false
+
 Metrics/ParameterLists:
   Max: 5
   CountKeywordArgs: false

--- a/lib/rails/auth.rb
+++ b/lib/rails/auth.rb
@@ -3,5 +3,8 @@
 # Pull in core library components that work with any Rack application
 require "rails/auth/rack"
 
+# Rails configuration builder
+require "rails/auth/config_builder"
+
 # Rails controller method support
 require "rails/auth/controller_methods"

--- a/lib/rails/auth/rspec/helper_methods.rb
+++ b/lib/rails/auth/rspec/helper_methods.rb
@@ -43,7 +43,7 @@ module Rails
         end
 
         Rails::Auth::ACL::Resource::HTTP_METHODS.each do |method|
-          define_method("#{method.downcase}_request") do |certificates: {}|
+          define_method("#{method.downcase}_request") do |credentials: {}|
             path = self.class.description
 
             # Warn if methods are improperly used
@@ -56,7 +56,7 @@ module Rails
               "PATH_INFO"      => self.class.description
             }
 
-            certificates.each do |type, value|
+            credentials.each do |type, value|
               Rails::Auth.add_credential(env, type.to_s, value)
             end
 

--- a/lib/rails/auth/rspec/helper_methods.rb
+++ b/lib/rails/auth/rspec/helper_methods.rb
@@ -3,6 +3,21 @@ module Rails
     module RSpec
       # RSpec helper methods
       module HelperMethods
+        # Credentials to be injected into the request during tests
+        def test_credentials
+          Rails.configuration.x.rails_auth.test_credentials
+        end
+
+        # Perform a test with the given credentials
+        # NOTE: Credentials will be *cleared* after the block. Nesting is not allowed.
+        def with_credentials(credentials = {})
+          raise TypeError, "expected Hash of credentials, got #{credentials.class}" unless credentials.is_a?(Hash)
+          test_credentials.clear
+          test_credentials.merge!(credentials)
+        ensure
+          test_credentials.clear
+        end
+
         # Creates an Rails::Auth::X509::Certificate instance double
         def x509_certificate(cn: nil, ou: nil)
           subject = ""

--- a/lib/rails/auth/rspec/helper_methods.rb
+++ b/lib/rails/auth/rspec/helper_methods.rb
@@ -13,7 +13,10 @@ module Rails
         def with_credentials(credentials = {})
           raise TypeError, "expected Hash of credentials, got #{credentials.class}" unless credentials.is_a?(Hash)
           test_credentials.clear
-          test_credentials.merge!(credentials)
+
+          credentials.each do |type, value|
+            test_credentials[type.to_s] = value
+          end
         ensure
           test_credentials.clear
         end

--- a/spec/rails/auth/rspec/helper_methods_spec.rb
+++ b/spec/rails/auth/rspec/helper_methods_spec.rb
@@ -1,6 +1,32 @@
+require "ostruct"
+
 RSpec.describe Rails::Auth::RSpec::HelperMethods, acl_spec: true do
   let(:example_cn) { "127.0.0.1" }
   let(:example_ou) { "ponycopter" }
+
+  before do
+    credentials   = {}
+    rails_auth    = double("config", test_credentials: credentials)
+    x_config      = double("config", rails_auth: rails_auth)
+    configuration = double("config", x: x_config)
+
+    allow(Rails).to receive(:configuration).and_return(configuration)
+  end
+
+  describe "#with_credentials" do
+    let(:example_credential_type)  { "x509" }
+    let(:example_credential_value) { x509_certificate(cn: example_cn, ou: example_ou) }
+
+    it "sets credentials in the Rails config" do
+      expect(test_credentials[example_credential_type]).to be_nil
+
+      with_credentials(example_credential_type => example_credential_value) do
+        expect(test_credentials[example_credential_type]).to be example_credential_value
+      end
+
+      expect(test_credentials[example_credential_type]).to be_nil
+    end
+  end
 
   describe "#x509_certificate" do
     subject { x509_certificate(cn: example_cn, ou: example_ou) }

--- a/spec/rails/auth/rspec/helper_methods_spec.rb
+++ b/spec/rails/auth/rspec/helper_methods_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Rails::Auth::RSpec::HelperMethods, acl_spec: true do
   end
 
   describe "#with_credentials" do
-    let(:example_credential_type)  { "x509" }
+    let(:example_credential_type)  { :x509 }
     let(:example_credential_value) { x509_certificate(cn: example_cn, ou: example_ou) }
 
     it "sets credentials in the Rails config" do

--- a/spec/rails/auth/rspec/matchers/acl_matchers_spec.rb
+++ b/spec/rails/auth/rspec/matchers/acl_matchers_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "RSpec ACL matchers", acl_spec: true do
   end
 
   describe "/baz/quux" do
-    it { is_expected.to permit get_request(certificates: example_certificate) }
-    it { is_expected.not_to permit get_request(certificates: another_certificate) }
+    it { is_expected.to permit get_request(credentials: example_certificate) }
+    it { is_expected.not_to permit get_request(credentials: another_certificate) }
     it { is_expected.not_to permit get_request }
   end
 end


### PR DESCRIPTION
Helper functions which build middleware chains for different environments.

Provides "convention over configuration" when using Rails::Auth inside a Rails app.