### PR TITLE
Rails::Auth::Monitor::Middleware

### DIFF
--- a/lib/rails/auth/monitor/middleware.rb
+++ b/lib/rails/auth/monitor/middleware.rb
@@ -1,0 +1,28 @@
+module Rails
+  module Auth
+    module Monitor
+      # Fires a user-specified callback which reports on authorization success
+      # or failure. Useful for logging or monitoring systems for AuthZ failures
+      class Middleware
+        def initialize(app, callback)
+          raise TypeError, "expected Proc callback, got #{callback.class}" unless callback.is_a?(Proc)
+
+          @app      = app
+          @callback = callback
+        end
+
+        def call(env)
+          begin
+            result = @app.call(env)
+          rescue Rails::Auth::NotAuthorizedError
+            @callback.call(env, false)
+            raise
+          end
+
+          @callback.call(env, true)
+          result
+        end
+      end
+    end
+  end
+end

--- a/lib/rails/auth/rack.rb
+++ b/lib/rails/auth/rack.rb
@@ -20,6 +20,8 @@ require "rails/auth/credentials/injector_middleware"
 require "rails/auth/error_page/middleware"
 require "rails/auth/error_page/debug_middleware"
 
+require "rails/auth/monitor/middleware"
+
 require "rails/auth/x509/certificate"
 require "rails/auth/x509/filter/pem"
 require "rails/auth/x509/filter/java" if defined?(JRUBY_VERSION)

--- a/spec/rails/auth/monitor/middleware_spec.rb
+++ b/spec/rails/auth/monitor/middleware_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe Rails::Auth::Monitor::Middleware do
+  let(:request) { Rack::MockRequest.env_for("https://www.example.com") }
+
+  describe "access granted" do
+    let(:code) { 200 }
+    let(:app)  { ->(env) { [code, env, "Hello, world!"] } }
+
+    it "fires the callback with the env and true" do
+      callback_fired = false
+
+      middleware = described_class.new(app, lambda do |env, success|
+        callback_fired = true
+        expect(env).to be_a Hash
+        expect(success).to eq true
+      end)
+
+      response = middleware.call(request)
+      expect(callback_fired).to eq true
+      expect(response.first).to eq code
+    end
+  end
+
+  describe "access denied" do
+    let(:app) { ->(_env) { raise(Rails::Auth::NotAuthorizedError, "not authorized!") } }
+
+    it "renders the error page" do
+      callback_fired = false
+
+      middleware = described_class.new(app, lambda do |env, success|
+        callback_fired = true
+        expect(env).to be_a Hash
+        expect(success).to eq false
+      end)
+
+      expect { middleware.call(request) }.to raise_error(Rails::Auth::NotAuthorizedError)
+      expect(callback_fired).to eq true
+    end
+  end
+end


### PR DESCRIPTION
Adds a middleware which fires a callback for every request which includes the Rack environment and whether or not the request was authorized.

Useful for logging AuthZ status of each request and/or reporting AuthZ failures to e.g. an alerting system.