### PR TITLE
Rails::Auth.allowed_by

### DIFF
--- a/lib/rails/auth/acl/matchers/allow_all.rb
+++ b/lib/rails/auth/acl/matchers/allow_all.rb
@@ -1,7 +1,7 @@
 module Rails
   module Auth
     class ACL
-      # Built-in predicate matchers
+      # Built-in matchers
       module Matchers
         # Allows unauthenticated clients to access to a given resource
         class AllowAll

--- a/lib/rails/auth/acl/middleware.rb
+++ b/lib/rails/auth/acl/middleware.rb
@@ -22,7 +22,12 @@ module Rails
         end
 
         def call(env)
-          raise NotAuthorizedError, "unauthorized request" unless Rails::Auth.authorized?(env) || @acl.match(env)
+          unless Rails::Auth.authorized?(env)
+            matcher_name = @acl.match(env)
+            raise NotAuthorizedError, "unauthorized request" unless matcher_name
+            Rails::Auth.set_allowed_by(env, "matcher:#{matcher_name}")
+          end
+
           @app.call(env)
         end
       end

--- a/lib/rails/auth/acl/resource.rb
+++ b/lib/rails/auth/acl/resource.rb
@@ -5,7 +5,7 @@ module Rails
     class ACL
       # Rules for a particular route
       class Resource
-        attr_reader :http_methods, :path, :host, :predicates
+        attr_reader :http_methods, :path, :host, :matchers
 
         # Valid HTTP methods
         HTTP_METHODS = %w(GET HEAD PUT POST DELETE OPTIONS PATCH LINK UNLINK).freeze
@@ -15,11 +15,11 @@ module Rails
 
         # @option :options [String] :method HTTP method allowed ("ALL" for all methods)
         # @option :options [String] :path path to the resource (regex syntax allowed)
-        # @param [Hash] :predicates matchers for this resource
+        # @param [Hash] :matchers which matchers are used for this resource
         #
-        def initialize(options, predicates)
-          raise TypeError, "expected Hash for options"    unless options.is_a?(Hash)
-          raise TypeError, "expected Hash for predicates" unless predicates.is_a?(Hash)
+        def initialize(options, matchers)
+          raise TypeError, "expected Hash for options"  unless options.is_a?(Hash)
+          raise TypeError, "expected Hash for matchers" unless matchers.is_a?(Hash)
 
           unless (extra_keys = options.keys - VALID_OPTIONS).empty?
             raise ParseError, "unrecognized key in ACL resource: #{extra_keys.first}"
@@ -30,7 +30,7 @@ module Rails
 
           @http_methods = extract_methods(methods)
           @path         = /\A#{path}\z/
-          @predicates   = predicates.freeze
+          @matchers     = matchers.freeze
 
           # Unlike method and path, host is optional
           host = options["host"]
@@ -38,19 +38,20 @@ module Rails
         end
 
         # Match this resource against the given Rack environment, checking all
-        # predicates to ensure at least one of them matches
+        # matchers to ensure at least one of them matches
         #
         # @param [Hash] :env Rack environment
         #
-        # @return [Boolean] resource and predicates match the given request
+        # @return [String, nil] name of the matcher which matched, or nil if none matched
         #
         def match(env)
-          return false unless match!(env)
-          @predicates.any? { |_name, predicate| predicate.match(env) }
+          return nil unless match!(env)
+          name, = @matchers.find { |_name, matcher| matcher.match(env) }
+          name
         end
 
         # Match *only* the request method/path/host against the given Rack environment.
-        # Predicates are NOT checked.
+        # matchers are NOT checked.
         #
         # @param [Hash] :env Rack environment
         #

--- a/lib/rails/auth/error_page/debug_page.html.erb
+++ b/lib/rails/auth/error_page/debug_page.html.erb
@@ -113,8 +113,8 @@
           <td class="label"><%= h((resource.http_methods || "ALL").join(" ")) %> <%= h(format_path(resource.path)) %></td>
           <td>
             <ul>
-              <% resource.predicates.each do |name, predicate| %>
-              <li><%= h(name) %>: <%= h(format_attributes(predicate)) %></li>
+              <% resource.matchers.each do |name, matcher| %>
+              <li><%= h(name) %>: <%= h(format_attributes(matcher)) %></li>
               <% end %>
             </ul>
           </td>

--- a/lib/rails/auth/override.rb
+++ b/lib/rails/auth/override.rb
@@ -9,8 +9,10 @@ module Rails
       # Mark a request as externally authorized. Causes ACL checks to be skipped.
       #
       # @param [Hash] :env Rack environment
+      # @param [String] :allowed_by what allowed the request
       #
-      def authorized!(env)
+      def authorized!(env, allowed_by = nil)
+        Rails::Auth.set_allowed_by(allowed_by) if allowed_by
         env[AUTHORIZED_ENV_KEY] = true
       end
 

--- a/lib/rails/auth/rack.rb
+++ b/lib/rails/auth/rack.rb
@@ -7,8 +7,8 @@ require "openssl"
 require "rails/auth/version"
 
 require "rails/auth/exceptions"
-
 require "rails/auth/override"
+require "rails/auth/result"
 
 require "rails/auth/acl"
 require "rails/auth/acl/middleware"

--- a/lib/rails/auth/result.rb
+++ b/lib/rails/auth/result.rb
@@ -1,0 +1,29 @@
+module Rails
+  # Modular resource-based authentication and authorization for Rails/Rack
+  module Auth
+    # Rack environment key for storing what allowed the request
+    ALLOWED_BY_ENV_KEY = "rails-auth.allowed-by".freeze
+
+    # Functionality for storing AuthZ results in the environment
+    module Result
+      # Mark what authorized the request
+      #
+      # @param [Hash] :env Rack environment
+      # @param [String] :allowed_by what allowed this request
+      def set_allowed_by(env, allowed_by)
+        env[ALLOWED_BY_ENV_KEY] = allowed_by
+      end
+
+      # Read what authorized the request
+      #
+      # @param [Hash] :env Rack environment
+      #
+      # @return [String, nil] what authorized the request
+      def allowed_by(env)
+        env[ALLOWED_BY_ENV_KEY]
+      end
+    end
+
+    extend Result
+  end
+end

--- a/lib/rails/auth/x509/matcher.rb
+++ b/lib/rails/auth/x509/matcher.rb
@@ -1,7 +1,7 @@
 module Rails
   module Auth
     module X509
-      # Predicate matcher for making assertions about X.509 certificates
+      # Matcher for making assertions about X.509 certificates
       class Matcher
         # @option options [String] cn Common Name of the subject
         # @option options [String] ou Organizational Unit of the subject

--- a/spec/rails/auth/acl/resource_spec.rb
+++ b/spec/rails/auth/acl/resource_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Rails::Auth::ACL::Resource do
   let(:example_path)   { "/foobar" }
   let(:another_path)   { "/baz" }
 
-  let(:example_predicates) { { "example" => double(:predicate, match: predicate_matches) } }
-  let(:example_resource)   { described_class.new(example_options, example_predicates) }
+  let(:example_matchers) { { "example" => double(:matcher, match: matcher_matches) } }
+  let(:example_resource)   { described_class.new(example_options, example_matchers) }
   let(:example_env)        { env_for(example_method, example_path) }
 
   describe "#initialize" do
@@ -59,37 +59,37 @@ RSpec.describe Rails::Auth::ACL::Resource do
     end
 
     describe "#match" do
-      context "with matching predicates and method/path" do
-        let(:predicate_matches) { true }
+      context "with matching matchers and method/path" do
+        let(:matcher_matches) { true }
 
         it "matches against a valid resource" do
-          expect(example_resource.match(example_env)).to eq true
+          expect(example_resource.match(example_env)).to eq "example"
         end
       end
 
-      context "without matching predicates" do
-        let(:predicate_matches) { false }
+      context "without matching matchers" do
+        let(:matcher_matches) { false }
 
         it "doesn't match against a valid resource" do
-          expect(example_resource.match(example_env)).to eq false
+          expect(example_resource.match(example_env)).to eq nil
         end
       end
 
       context "without a method/path match" do
-        let(:predicate_matches) { true }
+        let(:matcher_matches) { true }
 
         it "doesn't match" do
           env = env_for(another_method, example_path)
-          expect(example_resource.match(env)).to eq false
+          expect(example_resource.match(env)).to eq nil
         end
       end
     end
 
     describe "#match!" do
-      let(:predicate_matches) { false }
+      let(:matcher_matches) { false }
 
       it "matches against all methods if specified" do
-        resource = described_class.new(example_options.merge("method" => "ALL"), example_predicates)
+        resource = described_class.new(example_options.merge("method" => "ALL"), example_matchers)
         expect(resource.match!(example_env)).to eq true
       end
 
@@ -108,7 +108,7 @@ RSpec.describe Rails::Auth::ACL::Resource do
   context "with a host specified" do
     let(:example_host) { "www.example.com" }
     let(:bogus_host)   { "www.trololol.com" }
-    let(:predicate_matches) { true }
+    let(:matcher_matches) { true }
 
     let(:example_options) do
       {
@@ -121,24 +121,24 @@ RSpec.describe Rails::Auth::ACL::Resource do
     describe "#match" do
       it "matches if the host matches" do
         example_env["HTTP_HOST"] = example_host
-        expect(example_resource.match(example_env)).to eq true
+        expect(example_resource.match(example_env)).to eq "example"
       end
 
       it "doesn't match if the host mismatches" do
         example_env["HTTP_HOST"] = bogus_host
-        expect(example_resource.match(example_env)).to eq false
+        expect(example_resource.match(example_env)).to eq nil
       end
     end
 
     describe "#match!" do
       it "matches if the host matches" do
         example_env["HTTP_HOST"] = example_host
-        expect(example_resource.match(example_env)).to eq true
+        expect(example_resource.match(example_env)).to eq "example"
       end
 
       it "doesn't match if the host mismatches" do
         example_env["HTTP_HOST"] = bogus_host
-        expect(example_resource.match(example_env)).to eq false
+        expect(example_resource.match(example_env)).to eq nil
       end
     end
   end

--- a/spec/rails/auth/acl_spec.rb
+++ b/spec/rails/auth/acl_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Rails::Auth::ACL do
 
   describe "#match" do
     it "matches routes against the ACL" do
-      expect(example_acl.match(env_for(:get, "/"))).to eq true
-      expect(example_acl.match(env_for(:get, "/foo/bar/baz"))).to eq true
-      expect(example_acl.match(env_for(:get, "/_admin"))).to eq false
+      expect(example_acl.match(env_for(:get, "/"))).to eq "allow_all"
+      expect(example_acl.match(env_for(:get, "/foo/bar/baz"))).to eq "allow_claims"
+      expect(example_acl.match(env_for(:get, "/_admin"))).to eq nil
     end
   end
 


### PR DESCRIPTION
Store what authorized the request in the Rack environment.

This involved making some changes to the way ACL#match works to return the matcher that matched the request instead of just true/false.