### PR TITLE
Make allowed_by a mandatory argument of Rails::Auth.authorized!

### DIFF
--- a/lib/rails/auth/override.rb
+++ b/lib/rails/auth/override.rb
@@ -11,8 +11,10 @@ module Rails
       # @param [Hash] :env Rack environment
       # @param [String] :allowed_by what allowed the request
       #
-      def authorized!(env, allowed_by = nil)
-        Rails::Auth.set_allowed_by(allowed_by) if allowed_by
+      def authorized!(env, allowed_by)
+        raise TypeError, "expected string, got #{allowed_by.class}" unless allowed_by.is_a?(String)
+
+        Rails::Auth.set_allowed_by(env, allowed_by) if allowed_by
         env[AUTHORIZED_ENV_KEY] = true
       end
 

--- a/spec/rails/auth/acl/middleware_spec.rb
+++ b/spec/rails/auth/acl/middleware_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe Rails::Auth::ACL::Middleware do
         end
 
         def call(env)
-          Rails::Auth.authorized!(env)
+          allowed_by = "example"
+          Rails::Auth.authorized!(env, allowed_by)
           @app.call(env)
         end
       end


### PR DESCRIPTION
I released 2.0.0 with this as an optional argument, but I really think
it should be mandatory.

Nobody is using 2.0.0 yet, so for maximum semantic versioning correctness
I could yank it to ensure this backward incompatible change is consistent
for all 2.x releases, or just leave it as is and tell people 2.0.0 is
"broken".

Upon updating the spec, I did discover Rails::Auth.authorized! is calling
Rails::Auth.set_allowed_by incorrectly.