### PR TITLE
Make credentials idempotent

### DIFF
--- a/lib/rails/auth/credentials.rb
+++ b/lib/rails/auth/credentials.rb
@@ -10,7 +10,7 @@ module Rails
       extend Forwardable
       include Enumerable
 
-      def_delegators :@credentials, :[], :fetch, :empty?, :key?, :each, :to_hash
+      def_delegators :@credentials, :fetch, :empty?, :key?, :each, :to_hash
 
       def self.from_rack_env(env)
         new(env.fetch(Rails::Auth::Env::CREDENTIALS_ENV_KEY, {}))
@@ -22,9 +22,14 @@ module Rails
       end
 
       def []=(type, value)
+        return if @credentials.key?(type) && @credentials[type] == value
         raise TypeError, "expected String for type, got #{type.class}" unless type.is_a?(String)
         raise AlreadyAuthorizedError, "credential '#{type}' has already been set" if @credentials.key?(type)
         @credentials[type] = value
+      end
+
+      def [](type)
+        @credentials[type.to_s]
       end
     end
   end

--- a/spec/rails/auth/credentials_spec.rb
+++ b/spec/rails/auth/credentials_spec.rb
@@ -21,10 +21,29 @@ RSpec.describe Rails::Auth::Credentials do
     end
   end
 
-  describe "[]=" do
-    it "raises AlreadyAuthorizedError if credential has already been set" do
+  context "when called twice for the same credential type" do
+    let(:example_credential) { double(:credential1) }
+    let(:second_credential)  { double(:credential2) }
+
+    let(:example_env) { Rack::MockRequest.env_for("https://www.example.com") }
+
+    it "succeeds if the credentials are the same" do
+      allow(example_credential).to receive(:==).and_return(true)
+
+      Rails::Auth.add_credential(example_env, example_credential_type, example_credential)
+
       expect do
-        credentials[example_credential_type] = example_credential_value
+        Rails::Auth.add_credential(example_env, example_credential_type, second_credential)
+      end.to_not raise_error
+    end
+
+    it "raises Rails::Auth::AlreadyAuthorizedError if the credentials are different" do
+      allow(example_credential).to receive(:==).and_return(false)
+
+      Rails::Auth.add_credential(example_env, example_credential_type, example_credential)
+
+      expect do
+        Rails::Auth.add_credential(example_env, example_credential_type, second_credential)
       end.to raise_error(Rails::Auth::AlreadyAuthorizedError)
     end
   end


### PR DESCRIPTION
Changes Rails::Auth::AlreadyAuthorizedError to only be raised if credentials actually conflict.

Setting the same credential twice for the same type is ignored.