### PR TITLE
Bump supported Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,15 @@ before_install:
 bundler_args: --without development
 
 rvm:
-  - 2.0.0
-  - 2.1.10
-  - 2.2.4
-  - 2.3.0
+  - 2.4
+  - 2.5
+  - 2.6
 matrix:
   include:
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby
+      jdk: openjdk8
+      env: JRUBY_OPTS="--debug" # for simplecov
+    - rvm: jruby
+      jdk: openjdk11
       env: JRUBY_OPTS="--debug" # for simplecov
   fast_finish: true

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### Unreleased
+* [#57](https://github.com/square/rails-auth/pull/57)
+  Add support for latest versions of Ruby, JRuby and Bundler 2.
+  ([@mbyczkowski])
+
 ### 2.1.4 (2018-07-12)
 
 * [#51](https://github.com/square/rails-auth/pull/51)

--- a/lib/rails/auth/x509/filter/java.rb
+++ b/lib/rails/auth/x509/filter/java.rb
@@ -1,23 +1,12 @@
-require "java"
-require "stringio"
-
 module Rails
   module Auth
     module X509
       module Filter
-        # Extract OpenSSL::X509::Certificates from Java's sun.security.x509.X509CertImpl
+        # Extract OpenSSL::X509::Certificates from java.security.cert.Certificate
         class Java
           def call(certs)
-            return unless certs
-            OpenSSL::X509::Certificate.new(extract_der(certs[0])).freeze
-          end
-
-          private
-
-          def extract_der(cert)
-            stringio = StringIO.new
-            cert.derEncode(stringio.to_outputstream)
-            stringio.string
+            return if certs.nil? || certs.empty?
+            OpenSSL::X509::Certificate.new(certs[0].get_encoded).freeze
           end
         end
       end

--- a/rails-auth.gemspec
+++ b/rails-auth.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rack"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", ">= 1.10", "< 3"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/spec/rails/auth/x509/middleware_spec.rb
+++ b/spec/rails/auth/x509/middleware_spec.rb
@@ -49,10 +49,12 @@ RSpec.describe Rails::Auth::X509::Middleware do
 
       let(:java_cert) do
         ruby_cert = OpenSSL::X509::Certificate.new(valid_cert_pem)
-        Java::SunSecurityX509::X509CertImpl.new(ruby_cert.to_der.to_java_bytes)
+        input_stream = Java::JavaIO::ByteArrayInputStream.new(ruby_cert.to_der.to_java_bytes)
+        java_cert_klass = Java::JavaSecurityCert::CertificateFactory.getInstance("X.509")
+        java_cert_klass.generateCertificate(input_stream)
       end
 
-      it "extracts Rails::Auth::Credential::X509 from a Java::SunSecurityX509::X509CertImpl" do
+      it "extracts Rails::Auth::Credential::X509 from a java.security.cert.Certificate" do
         skip "JRuby only" unless defined?(JRUBY_VERSION)
 
         _response, env = middleware.call(request.merge(example_key => [java_cert]))


### PR DESCRIPTION
- Bumped MRI Rubies to the ones that are still supported
- Bumped JRuby to the last 2 releases. This required a change to how
  Java certificates are created in test (sun.security.x509.X509CertImpl
  can no longer be directly instantiated).