### PR TITLE
Expose Subject Alternative Name information in the certificate

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   DisplayCopNames: true
+  TargetRubyVersion: 2.3
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,11 @@
 ### Unreleased
+
+* [#59](https://github.com/square/rails-auth/pull/59)
+  Expose X.509 Subject Alternative Name extension
+  in the Rails::Auth::X509::Certificate and provide a convenience
+  method `spiffe_id` to expose [SPIFFE ID](https://spiffe.io).
+  (@mbyczkowski)
+
 * [#57](https://github.com/square/rails-auth/pull/57)
   Add support for latest versions of Ruby, JRuby and Bundler 2.
   ([@mbyczkowski])

--- a/lib/rails/auth/rack.rb
+++ b/lib/rails/auth/rack.rb
@@ -27,3 +27,4 @@ require "rails/auth/x509/filter/pem"
 require "rails/auth/x509/filter/java" if defined?(JRUBY_VERSION)
 require "rails/auth/x509/matcher"
 require "rails/auth/x509/middleware"
+require "rails/auth/x509/subject_alt_name_extension"

--- a/lib/rails/auth/x509/certificate.rb
+++ b/lib/rails/auth/x509/certificate.rb
@@ -18,7 +18,8 @@ module Rails
           @certificate.subject.to_a.each do |name, data, _type|
             @subject[name.freeze] = data.freeze
           end
-
+          @subject_alt_names = SubjectAltNameExtension.new(certificate)
+          @subject_alt_names.freeze
           @subject.freeze
         end
 
@@ -31,19 +32,48 @@ module Rails
         end
         alias common_name cn
 
+        def dns_names
+          @subject_alt_names.dns_names
+        end
+
+        def ips
+          @subject_alt_names.ips
+        end
+
         def ou
           @subject["OU"]
         end
         alias organizational_unit ou
 
+        def uris
+          @subject_alt_names.uris
+        end
+
+        # According to the SPIFFE standard only one SPIFFE ID can exist in the URI
+        # SAN:
+        # (https://github.com/spiffe/spiffe/blob/master/standards/X509-SVID.md#2-spiffe-id)
+        #
+        # @return [String, nil] string containing SPIFFE ID if one is present
+        #         in the certificate
+        def spiffe_id
+          uris.detect { |uri| uri.start_with?("spiffe://") }
+        end
+
         # Generates inspectable attributes for debugging
         #
         # @return [Hash] hash containing parts of the certificate subject (cn, ou)
+        #         and subject alternative name extension (uris, dns_names) as well
+        #         as SPIFFE ID (spiffe_id), which is just a convenience since those
+        #         are already included in the uris
         def attributes
           {
             cn: cn,
-            ou: ou
-          }
+            dns_names: dns_names,
+            ips: ips,
+            ou: ou,
+            spiffe_id: spiffe_id,
+            uris: uris
+          }.reject { |_, v| v.nil? || v.empty? }
         end
 
         # Compare ourself to another object by ensuring that it has the same type

--- a/lib/rails/auth/x509/subject_alt_name_extension.rb
+++ b/lib/rails/auth/x509/subject_alt_name_extension.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Rails
+  module Auth
+    module X509
+      # Provides convenience methods for subjectAltName extension of X.509 certificates
+      class SubjectAltNameExtension
+        attr_reader :dns_names, :ips, :uris
+
+        DNS_REGEX = /^DNS:/i.freeze
+        IP_REGEX  = /^IP( Address)?:/i.freeze
+        URI_REGEX = /^URI:/i.freeze
+
+        def initialize(certificate)
+          unless certificate.is_a?(OpenSSL::X509::Certificate)
+            raise TypeError, "expecting OpenSSL::X509::Certificate, got #{certificate.class}"
+          end
+
+          extension = certificate.extensions.detect { |ext| ext.oid == "subjectAltName" }
+          values = (extension&.value&.split(",") || []).map(&:strip)
+
+          @dns_names = values.grep(DNS_REGEX) { |v| v.sub(DNS_REGEX, "") }.freeze
+          @ips = values.grep(IP_REGEX) { |v| v.sub(IP_REGEX, "") }.freeze
+          @uris = values.grep(URI_REGEX) { |v| v.sub(URI_REGEX, "") }.freeze
+        end
+      end
+    end
+  end
+end

--- a/spec/rails/auth/x509/certificate_spec.rb
+++ b/spec/rails/auth/x509/certificate_spec.rb
@@ -2,39 +2,120 @@
 
 RSpec.describe Rails::Auth::X509::Certificate do
   let(:example_cert) { OpenSSL::X509::Certificate.new(cert_path("valid.crt").read) }
+  let(:example_cert_with_extension) { OpenSSL::X509::Certificate.new(cert_path("valid_with_ext.crt").read) }
   let(:example_certificate) { described_class.new(example_cert) }
+  let(:example_certificate_with_extension) { described_class.new(example_cert_with_extension) }
 
   let(:example_cn) { "127.0.0.1" }
+  let(:example_dns_names) { %w[example.com exemplar.com somethingelse.com] }
+  let(:example_ips) { %w[0.0.0.0 127.0.0.1 192.168.1.1] }
   let(:example_ou) { "ponycopter" }
+  let(:example_spiffe) { "spiffe://example.com/exemplar" }
+  let(:example_uris) { [example_spiffe, "https://www.example.com/page1", "https://www.example.com/page2"] }
 
-  describe "#[]" do
-    it "allows access to subject components via strings" do
-      expect(example_certificate["CN"]).to eq example_cn
-      expect(example_certificate["OU"]).to eq example_ou
+  describe "without extensions" do
+    describe "#[]" do
+      it "allows access to subject components via strings" do
+        expect(example_certificate["CN"]).to eq example_cn
+        expect(example_certificate["OU"]).to eq example_ou
+      end
+
+      it "allows access to subject components via symbols" do
+        expect(example_certificate[:cn]).to eq example_cn
+        expect(example_certificate[:ou]).to eq example_ou
+      end
     end
 
-    it "allows access to subject components via symbols" do
-      expect(example_certificate[:cn]).to eq example_cn
-      expect(example_certificate[:ou]).to eq example_ou
+    it "knows its #cn" do
+      expect(example_certificate.cn).to eq example_cn
+    end
+
+    it "has no #dns_names" do
+      expect(example_certificate.dns_names).to be_empty
+    end
+
+    it "has no #ips" do
+      expect(example_certificate.ips).to be_empty
+    end
+
+    it "knows its #ou" do
+      expect(example_certificate.ou).to eq example_ou
+    end
+
+    it "has no #uris" do
+      expect(example_certificate.uris).to be_empty
+    end
+
+    it "has no #spiffe_id" do
+      expect(example_certificate.spiffe_id).to be_nil
+    end
+
+    it "knows its attributes" do
+      expect(example_certificate.attributes).to eq(cn: example_cn, ou: example_ou)
+    end
+
+    it "compares certificate objects by comparing their certificates" do
+      second_cert = OpenSSL::X509::Certificate.new(cert_path("valid.crt").read)
+      second_certificate = described_class.new(second_cert)
+
+      expect(example_certificate).to be_eql second_certificate
     end
   end
 
-  it "knows its #cn" do
-    expect(example_certificate.cn).to eq example_cn
-  end
+  describe "with extensions" do
+    describe "#[]" do
+      it "allows access to subject components via strings" do
+        expect(example_certificate_with_extension["CN"]).to eq example_cn
+        expect(example_certificate_with_extension["OU"]).to eq example_ou
+      end
 
-  it "knows its #ou" do
-    expect(example_certificate.ou).to eq example_ou
-  end
+      it "allows access to subject components via symbols" do
+        expect(example_certificate_with_extension[:cn]).to eq example_cn
+        expect(example_certificate_with_extension[:ou]).to eq example_ou
+      end
+    end
 
-  it "knows its attributes" do
-    expect(example_certificate.attributes).to eq(cn: example_cn, ou: example_ou)
-  end
+    it "knows its #cn" do
+      expect(example_certificate_with_extension.cn).to eq example_cn
+    end
 
-  it "compares certificate objects by comparing their certificates" do
-    second_cert = OpenSSL::X509::Certificate.new(cert_path("valid.crt").read)
-    second_certificate = described_class.new(second_cert)
+    it "knows its #dns_names" do
+      expect(example_certificate_with_extension.dns_names).to eq example_dns_names
+    end
 
-    expect(example_certificate).to be_eql second_certificate
+    it "knows its #ips" do
+      expect(example_certificate_with_extension.ips).to eq example_ips
+    end
+
+    it "knows its #ou" do
+      expect(example_certificate_with_extension.ou).to eq example_ou
+    end
+
+    it "knows its #spiffe_id" do
+      expect(example_certificate_with_extension.spiffe_id).to eq example_spiffe
+    end
+
+    it "knows its #uris" do
+      expect(example_certificate_with_extension.uris).to eq example_uris
+    end
+
+    it "knows its attributes" do
+      expected_attrs = {
+        cn: example_cn,
+        dns_names: example_dns_names,
+        ips: example_ips,
+        ou: example_ou,
+        spiffe_id: example_spiffe,
+        uris: example_uris
+      }
+      expect(example_certificate_with_extension.attributes).to eq(expected_attrs)
+    end
+
+    it "compares certificate objects by comparing their certificates" do
+      second_cert = OpenSSL::X509::Certificate.new(cert_path("valid_with_ext.crt").read)
+      second_certificate = described_class.new(second_cert)
+
+      expect(example_certificate_with_extension).to be_eql second_certificate
+    end
   end
 end

--- a/spec/rails/auth/x509/subject_alt_name_extension_spec.rb
+++ b/spec/rails/auth/x509/subject_alt_name_extension_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe Rails::Auth::X509::SubjectAltNameExtension do
+  let(:example_cert) { OpenSSL::X509::Certificate.new(cert_path("valid.crt").read) }
+  let(:example_cert_with_extension) { OpenSSL::X509::Certificate.new(cert_path("valid_with_ext.crt").read) }
+  let(:extension_for_cert) { described_class.new(example_cert) }
+  let(:extension_for_cert_with_san) { described_class.new(example_cert_with_extension) }
+  let(:example_dns_names) { %w[example.com exemplar.com somethingelse.com] }
+  let(:example_ips) { %w[0.0.0.0 127.0.0.1 192.168.1.1] }
+  let(:example_uris) { %w[spiffe://example.com/exemplar https://www.example.com/page1 https://www.example.com/page2] }
+
+  describe "for cert without extensions" do
+    it "returns no DNS names" do
+      expect(extension_for_cert.dns_names).to be_empty
+    end
+
+    it "returns no IPs" do
+      expect(extension_for_cert.ips).to be_empty
+    end
+
+    it "returns no URIs" do
+      expect(extension_for_cert.uris).to be_empty
+    end
+  end
+
+  describe "for cert with extensions" do
+    it "knows its DNS names" do
+      expect(extension_for_cert_with_san.dns_names).to eq example_dns_names
+    end
+
+    it "knows its IPs" do
+      expect(extension_for_cert_with_san.ips).to eq example_ips
+    end
+
+    it "knows its URIs" do
+      expect(extension_for_cert_with_san.uris).to eq example_uris
+    end
+  end
+end

--- a/spec/support/create_certs.rb
+++ b/spec/support/create_certs.rb
@@ -44,6 +44,59 @@ File.write valid_cert_path, valid_cert.to_pem
 File.write valid_key_path,  valid_cert.key_material.private_key.to_pem
 
 #
+# Valid client certificate with extensions
+#
+
+valid_cert_with_ext = CertificateAuthority::Certificate.new
+valid_cert_with_ext.subject.common_name = "127.0.0.1"
+valid_cert_with_ext.subject.organizational_unit = "ponycopter"
+valid_cert_with_ext.serial_number.number = 3
+valid_cert_with_ext.key_material.generate_key
+signing_profile = {
+  "extensions" => {
+    "basicConstraints" => {
+      "ca" => false
+    },
+    "crlDistributionPoints" => {
+      "uri" => "http://notme.com/other.crl"
+    },
+    "subjectKeyIdentifier" => {},
+    "authorityKeyIdentifier" => {},
+    "authorityInfoAccess" => {
+      "ocsp" => %w[http://youFillThisOut/ocsp/]
+    },
+    "keyUsage" => {
+      "usage" => %w[digitalSignature keyEncipherment dataEncipherment]
+    },
+    "extendedKeyUsage" => {
+      "usage" => %w[serverAuth clientAuth]
+    },
+    "subjectAltName" => {
+      "uris" => %w[spiffe://example.com/exemplar https://www.example.com/page1 https://www.example.com/page2],
+      "ips" => %w[0.0.0.0 127.0.0.1 192.168.1.1],
+      "dns_names" => %w[example.com exemplar.com somethingelse.com]
+    },
+    "certificatePolicies" => {
+      "policy_identifier" => "1.3.5.8",
+      "cps_uris" => %w[http://my.host.name/ http://my.your.name/],
+      "user_notice" => {
+        "explicit_text" => "Explicit Text Here",
+        "organization" => "Organization name",
+        "notice_numbers" => "1,2,3,4"
+      }
+    }
+  }
+}
+valid_cert_with_ext.parent = ca
+valid_cert_with_ext.sign!(signing_profile)
+
+valid_cert_with_ext_path = File.join(cert_path, "valid_with_ext.crt")
+valid_key_with_ext_path  = File.join(cert_path, "valid_with_ext.key")
+
+File.write valid_cert_with_ext_path, valid_cert_with_ext.to_pem
+File.write valid_key_with_ext_path,  valid_cert_with_ext.key_material.private_key.to_pem
+
+#
 # Create evil MitM self-signed certificate
 #
 


### PR DESCRIPTION
This is useful, because:
1) CN is deprecated and domain information should be provided in the
subjectAltName extension, known as DNS SAN
2) There are some emerging standards that encode identity in the URI SAN
(e.g. [SPIFFE](https://spiffe.io)