### PR TITLE
Remove ca_file, require_cert, and truststore options to X509 middleware

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+### Unreleased
+
+* [#67](https://github.com/square/rails-auth/pull/67)
+  Remove `ca_file`, `require_cert`, and `truststore` options to X509 middleware
+  as we no longer verify the certificate chain.
+  ([@drcapulet])
+
 ### 2.2.2 (2020-07-02)
 
 * [#65](https://github.com/square/rails-auth/pull/65)

--- a/spec/support/create_certs.rb
+++ b/spec/support/create_certs.rb
@@ -95,20 +95,3 @@ valid_key_with_ext_path  = File.join(cert_path, "valid_with_ext.key")
 
 File.write valid_cert_with_ext_path, valid_cert_with_ext.to_pem
 File.write valid_key_with_ext_path,  valid_cert_with_ext.key_material.private_key.to_pem
-
-#
-# Create evil MitM self-signed certificate
-#
-
-self_signed_cert = CertificateAuthority::Certificate.new
-self_signed_cert.subject.common_name = "127.0.0.1"
-self_signed_cert.subject.organizational_unit = "ponycopter"
-self_signed_cert.serial_number.number = 2
-self_signed_cert.key_material.generate_key
-self_signed_cert.sign!
-
-self_signed_cert_path = File.join(cert_path, "invalid.crt")
-self_signed_key_path  = File.join(cert_path, "invalid.key")
-
-File.write self_signed_cert_path, self_signed_cert.to_pem
-File.write self_signed_key_path,  self_signed_cert.key_material.private_key.to_pem


### PR DESCRIPTION
Since the middleware isn't the one managing the TLS connection, we already have to rely on whatever is managing the TLS connection to verify & pass it down into the Rack environment safely. Verifying it in the middleware simply proves you know the cert (which are more or less public) and doesn't prove ownership of the underlying private key.