### PR TITLE
Support URL-encoded PEMs to support new Puma header requirements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### Unreleased
+
+* [#70](https://github.com/square/rails-auth/pull/70)
+  Support URL-encoded PEMs to support new Puma header requirements.
+  ([@drcapulet])
+
 ### 3.0.0 (2020-08-10)
 
 * [#68](https://github.com/square/rails-auth/pull/68)

--- a/lib/rails/auth/rack.rb
+++ b/lib/rails/auth/rack.rb
@@ -24,6 +24,7 @@ require "rails/auth/monitor/middleware"
 
 require "rails/auth/x509/certificate"
 require "rails/auth/x509/filter/pem"
+require "rails/auth/x509/filter/pem_urlencoded"
 require "rails/auth/x509/filter/java" if defined?(JRUBY_VERSION)
 require "rails/auth/x509/matcher"
 require "rails/auth/x509/middleware"

--- a/lib/rails/auth/x509/filter/pem_urlencoded.rb
+++ b/lib/rails/auth/x509/filter/pem_urlencoded.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Rails
+  module Auth
+    module X509
+      module Filter
+        # Extract OpenSSL::X509::Certificates from Privacy Enhanced Mail (PEM) certificates
+        # that are URL encoded ($ssl_client_escaped_cert from Nginx).
+        class PemUrlencoded < Pem
+          def call(encoded_pem)
+            super(URI.decode_www_form_component(encoded_pem))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
With Puma 5.5.1, LF characters are no longer allowed in headers. In addition, `$ssl_client_cert` in Nginx has been deprecated in favor of `$ssl_client_escaped_cert`.