### PR TITLE
Adds Ruby 3.1 and 3.2 to CI

### DIFF
--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -16,7 +16,7 @@ jobs:
           - 11
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Java
       uses: actions/setup-java@v2
       with:

--- a/.github/workflows/mri.yml
+++ b/.github/workflows/mri.yml
@@ -14,7 +14,8 @@ jobs:
         ruby-version:
           - 2.6
           - 2.7
-          - 3.0
+          - '3.0'
+          - 3.1
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/mri.yml
+++ b/.github/workflows/mri.yml
@@ -16,9 +16,10 @@ jobs:
           - 2.7
           - '3.0'
           - 3.1
+          - 3.2
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,7 @@ end
 
 group :development, :test do
   gem "activesupport", "~> 4"
-  gem "certificate_authority", require: false,
-    git: "https://github.com/petergoldstein/certificate_authority.git", branch: "feature/accomodate_immutable_ssl_config"
+  gem "certificate_authority", require: false
   gem "coveralls", require: false
   # Workaround for: https://github.com/bundler/bundler/pull/4650
   gem "rack", "~> 1.x"

--- a/Gemfile
+++ b/Gemfile
@@ -8,13 +8,14 @@ end
 
 group :development, :test do
   gem "activesupport", "~> 4"
-  gem "certificate_authority", require: false
+  gem "certificate_authority", require: false,
+    git: "https://github.com/petergoldstein/certificate_authority.git", branch: "feature/accomodate_immutable_ssl_config"
   gem "coveralls", require: false
   # Workaround for: https://github.com/bundler/bundler/pull/4650
   gem "rack", "~> 1.x"
   gem "rake"
   gem "rspec"
-  gem "rubocop", "0.77.0"
+  gem "rubocop", "~> 1.0"
 end
 
 gemspec

--- a/lib/rails/auth/rspec/matchers/acl_matchers.rb
+++ b/lib/rails/auth/rspec/matchers/acl_matchers.rb
@@ -6,7 +6,7 @@ RSpec::Matchers.define(:permit) do |env|
     credentials = Rails::Auth.credentials(env)
     message     = "allow #{method}s by "
 
-    return message + "unauthenticated clients" if credentials.count.zero?
+    return "#{message}unauthenticated clients" if credentials.count.zero?
 
     message + credentials.values.map(&:inspect).join(", ")
   end

--- a/lib/rails/auth/x509/subject_alt_name_extension.rb
+++ b/lib/rails/auth/x509/subject_alt_name_extension.rb
@@ -19,9 +19,13 @@ module Rails
           extension = certificate.extensions.detect { |ext| ext.oid == "subjectAltName" }
           values = (extension&.value&.split(",") || []).map(&:strip)
 
-          @dns_names = values.grep(DNS_REGEX) { |v| v.sub(DNS_REGEX, "") }.freeze
-          @ips = values.grep(IP_REGEX) { |v| v.sub(IP_REGEX, "") }.freeze
-          @uris = values.grep(URI_REGEX) { |v| v.sub(URI_REGEX, "") }.freeze
+          @dns_names = filtered_names(DNS_REGEX, values)
+          @ips = filtered_names(IP_REGEX, values)
+          @uris = filtered_names(URI_REGEX, values)
+        end
+
+        def filtered_names(regex, values)
+          values.grep(regex) { |v| v.sub(regex, "") }.freeze
         end
       end
     end

--- a/rails-auth.gemspec
+++ b/rails-auth.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.3.0" # rubocop:disable Gemspec/RequiredRubyVersion
 
   spec.add_runtime_dependency "rack"
 

--- a/spec/rails/auth/x509/middleware_spec.rb
+++ b/spec/rails/auth/x509/middleware_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Rails::Auth::X509::Middleware do
     described_class.new(
       app,
       cert_filters: { example_key => cert_filter },
-      logger: Logger.new(STDERR)
+      logger: Logger.new($stderr)
     )
   end
 


### PR DESCRIPTION
Includes a Rubocop update to a compatible version and fixing a few lints.
Quotes the "3.0" in the GitHub Actions config to avoid truncation to "3".
Updates the checkout actions versions.